### PR TITLE
Improve vendor and badge validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Install in editable mode and run the provided commands:
 
 ```bash
 pip install -e .[test]
-validate-vendor path/to/vendor.json
-python -m openauthcert_tooling validate-badge path/to/badge.json
+tooling validate-vendor path/to/vendor.json
+tooling validate-badge path/to/badge.json
 ```
 
 ## Exit Codes

--- a/src/openauthcert_tooling/__main__.py
+++ b/src/openauthcert_tooling/__main__.py
@@ -1,8 +1,9 @@
 import argparse
-from .validate_badge import validate_badge_main
-from .validate_vendor import validate_vendor_main
+import sys
+from .validate_badge import main as validate_badge_main
+from .validate_vendor import main as validate_vendor_main
 
-def main():
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="OpenAuthCert Tooling CLI")
     subparsers = parser.add_subparsers(dest="command")
 
@@ -12,14 +13,14 @@ def main():
     vendor_parser = subparsers.add_parser("validate-vendor", help="Validate a vendor JSON file")
     vendor_parser.add_argument("file", help="Path to the vendor JSON file")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.command == "validate-badge":
-        validate_badge_main(args.file)
-    elif args.command == "validate-vendor":
-        validate_vendor_main(args.file)
-    else:
-        parser.print_help()
+        return validate_badge_main([args.file])
+    if args.command == "validate-vendor":
+        return validate_vendor_main([args.file])
+    parser.print_help()
+    return 0
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    sys.exit(main())

--- a/src/openauthcert_tooling/validate_badge.py
+++ b/src/openauthcert_tooling/validate_badge.py
@@ -1,20 +1,89 @@
+import argparse
+import json
+import re
 import subprocess
 import sys
 import tempfile
 import urllib.request
+from urllib.parse import urlparse
 
-def validate_badge_main(file_path):
-    schema_url = "https://raw.githubusercontent.com/openauthcert/badge-spec/main/schema/badge-schema.json"
+SCHEMA_URL = "https://raw.githubusercontent.com/openauthcert/badge-spec/main/schema/badge-schema.json"
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+
+VALID_STATUSES = {"certified", "revoked", "expired"}
+PROTOCOLS = {"OIDC", "SAML", "LDAP"}
+
+
+def validate_badge_main(file_path: str) -> int:
+    """Validate a badge JSON file against the specification."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # noqa: BLE001 - print error for CLI users
+        print(f"Invalid JSON file: {exc}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+
+    protocols = data.get("auth_protocols") or []
+    if not isinstance(protocols, list) or not any(p in PROTOCOLS for p in protocols):
+        errors.append(
+            "'auth_protocols' must contain at least one of OIDC, SAML, or LDAP"
+        )
+
+    docs_url = data.get("docs_url")
+    parsed = urlparse(str(docs_url)) if docs_url else None
+    if not parsed or parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        errors.append("'docs_url' must be a valid URL")
+    else:
+        try:
+            with urllib.request.urlopen(docs_url) as resp:
+                if resp.status >= 400:
+                    errors.append("'docs_url' is not reachable")
+        except Exception:  # noqa: BLE001 - network errors for CLI users
+            errors.append("'docs_url' is not reachable")
+
+    version = data.get("version")
+    if not version or not isinstance(version, str) or not SEMVER_RE.match(version):
+        errors.append("'version' must be a valid semantic version (MAJOR.MINOR.PATCH)")
+
+    status = data.get("status")
+    if status not in VALID_STATUSES:
+        errors.append(
+            "'status' must be one of: certified, revoked, expired"
+        )
+
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        return 1
+
     try:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as temp_schema:
-            urllib.request.urlretrieve(schema_url, temp_schema.name)
+            urllib.request.urlretrieve(SCHEMA_URL, temp_schema.name)
             subprocess.run([
                 "check-jsonschema",
-                "--schemafile", temp_schema.name,
-                file_path
+                "--schemafile",
+                temp_schema.name,
+                file_path,
             ], check=True)
     except subprocess.CalledProcessError:
-        sys.exit(1)
-    except Exception as e:
+        return 1
+    except Exception as e:  # noqa: BLE001 - print error for CLI users
         print(f"Error fetching or validating schema: {e}", file=sys.stderr)
-        sys.exit(1)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a badge JSON file")
+    parser.add_argument("file", help="Path to the badge JSON file")
+    args = parser.parse_args(argv)
+    return validate_badge_main(args.file)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    sys.exit(main())

--- a/src/openauthcert_tooling/validate_vendor.py
+++ b/src/openauthcert_tooling/validate_vendor.py
@@ -1,15 +1,22 @@
 """Validate vendor JSON files against the badge specification schema."""
 
 import argparse
+import json
+import re
 import subprocess
 import sys
 import tempfile
 import urllib.request
+from urllib.parse import urlparse
 
 
 SCHEMA_URL = (
     "https://raw.githubusercontent.com/openauthcert/"
     "badge-spec/main/specs/v1.0.0/badge-schema.json"
+)
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
 )
 
 
@@ -18,6 +25,34 @@ def validate_vendor(file_path: str) -> int:
 
     Returns 0 on success and 1 on failure.
     """
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # noqa: BLE001 - print error for CLI users
+        print(f"Invalid JSON file: {exc}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+
+    auth = data.get("auth", {}) if isinstance(data.get("auth"), dict) else {}
+    if not any(auth.get(p) is True for p in ("oidc", "saml", "ldap")):
+        errors.append(
+            "At least one of 'auth.oidc', 'auth.saml', or 'auth.ldap' must be true"
+        )
+
+    doc_url = data.get("documentation")
+    if not doc_url or not urlparse(str(doc_url)).scheme or not urlparse(str(doc_url)).netloc:
+        errors.append("Field 'documentation' must be a valid URL")
+
+    version = data.get("version")
+    if not version or not isinstance(version, str) or not SEMVER_RE.match(version):
+        errors.append("Field 'version' must be a valid semantic version (MAJOR.MINOR.PATCH)")
+
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        return 1
+
     try:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as temp_schema:
             urllib.request.urlretrieve(SCHEMA_URL, temp_schema.name)

--- a/tests/test_validate_badge_cli.py
+++ b/tests/test_validate_badge_cli.py
@@ -1,0 +1,52 @@
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from openauthcert_tooling import validate_badge
+
+
+def make_fake_schema(monkeypatch):
+    def fake_urlretrieve(url, filename, *args, **kwargs):
+        Path(filename).write_text("{}")
+        return filename, None
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr(validate_badge.urllib.request, "urlretrieve", fake_urlretrieve)
+    monkeypatch.setattr(validate_badge.subprocess, "run", fake_run)
+
+    class DummyResponse:
+        def __init__(self, status=200):
+            self.status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(validate_badge.urllib.request, "urlopen", lambda url: DummyResponse())
+
+
+
+def test_badge_missing_fields(monkeypatch, tmp_path):
+    make_fake_schema(monkeypatch)
+    badge_file = tmp_path / "badge.json"
+    badge_file.write_text("{}")
+    assert validate_badge.main([str(badge_file)]) == 1
+
+
+def test_badge_valid(monkeypatch, tmp_path):
+    make_fake_schema(monkeypatch)
+    badge_file = tmp_path / "badge.json"
+    badge = {
+        "auth_protocols": ["OIDC"],
+        "docs_url": "https://example.com",
+        "version": "1.0.0",
+        "status": "certified",
+    }
+    badge_file.write_text(__import__("json").dumps(badge))
+    assert validate_badge.main([str(badge_file)]) == 0

--- a/tests/test_validate_vendor.py
+++ b/tests/test_validate_vendor.py
@@ -22,3 +22,41 @@ def test_main_error(monkeypatch, tmp_path):
     monkeypatch.setattr(validate_vendor.subprocess, "run", fake_run)
 
     assert validate_vendor.main([str(vendor_file)]) == 1
+
+
+def test_vendor_missing_protocols(monkeypatch, tmp_path):
+    vendor_file = tmp_path / "vendor.json"
+    vendor_file.write_text(
+        '{"documentation": "https://example.com", "version": "1.0.0"}'
+    )
+
+    def fake_urlretrieve(url, filename, *args, **kwargs):
+        Path(filename).write_text("{}")
+        return filename, None
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr(validate_vendor.urllib.request, "urlretrieve", fake_urlretrieve)
+    monkeypatch.setattr(validate_vendor.subprocess, "run", fake_run)
+
+    assert validate_vendor.main([str(vendor_file)]) == 1
+
+
+def test_vendor_valid(monkeypatch, tmp_path):
+    vendor_file = tmp_path / "vendor.json"
+    vendor_file.write_text(
+        '{"documentation": "https://example.com", "version": "1.0.0", "auth": {"oidc": true}}'
+    )
+
+    def fake_urlretrieve(url, filename, *args, **kwargs):
+        Path(filename).write_text("{}")
+        return filename, None
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 0)
+
+    monkeypatch.setattr(validate_vendor.urllib.request, "urlretrieve", fake_urlretrieve)
+    monkeypatch.setattr(validate_vendor.subprocess, "run", fake_run)
+
+    assert validate_vendor.main([str(vendor_file)]) == 0


### PR DESCRIPTION
## Summary
- expand vendor JSON validation to check auth options, version and documentation
- implement stricter badge checks for auth protocols, status, docs URL and version
- expose new CLI helpers and update usage examples
- add tests for new validation routines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ea19fbb48323ad32fc2ed167ba9f